### PR TITLE
Empty newsfeed matches empty performance style

### DIFF
--- a/app/views/articles/_news_feed.html.haml
+++ b/app/views/articles/_news_feed.html.haml
@@ -1,8 +1,7 @@
 %section.news-feed
   - if articles.length > 0
     - articles.each do |article|
-      .news-article
-        = render '/articles/show', article: article
+      = render '/articles/thumb', article: article
   - else
     .row
       .column.small-12

--- a/app/views/articles/_thumbnail_feed.html.haml
+++ b/app/views/articles/_thumbnail_feed.html.haml
@@ -1,6 +1,0 @@
-%section.news-feed
-  - if articles.length > 0
-    - articles.each do |article|
-      = render '/articles/thumb', article: article
-  - else
-    %p.column.small-12 Stay tuned for more information soon!

--- a/app/views/articles/index.html.haml
+++ b/app/views/articles/index.html.haml
@@ -15,4 +15,4 @@
     = link_to 'Add Article', new_article_path,
       class: 'button small round hide-for-medium-down large-1 column'
 
-= render 'thumbnail_feed', articles: @articles
+= render 'news_feed', articles: @articles


### PR DESCRIPTION
If there were no news items, the no content view was only a plain
paragraph that flowed outside of the layout. This restructures the HTML
inherit styles from Foundation and used by the performance page when
there is no content there.

https://github.com/calraijintaiko/caltaiko/issues/19

![image](https://cloud.githubusercontent.com/assets/681189/14305647/3d642376-fb73-11e5-9e6c-20ade8f8081a.png)
