### PR TITLE
Add quiet_assets gem to development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,4 +108,5 @@ group :development do
   gem 'web-console'
   gem 'pry-rails'
   gem 'pry-byebug', '~>3.3.0'
+  gem 'quiet_assets'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,6 +258,8 @@ GEM
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
+    quiet_assets (1.1.0)
+      railties (>= 3.1, < 5.0)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -452,6 +454,7 @@ DEPENDENCIES
   pg
   pry-byebug (~> 3.3.0)
   pry-rails
+  quiet_assets
   rails (~> 4.2.0)
   rails_12factor
   rb-fsevent


### PR DESCRIPTION
When developing, having asset requests in the log is usually more
distracting than it is helpful. Removing these requests with
quite_assets makes debugging easier by only showing errors.

https://github.com/calraijintaiko/caltaiko/issues/68

Before:
![Before](http://www.rubyonrails365.com/images/2015/feb/quietassetsbefore-54617fe1.png)

After:
![After](http://www.rubyonrails365.com/images/2015/feb/quietassetsafter-be15de01.png)