### PR TITLE
Paginate news articles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,9 @@ gem 'friendly_id', '~> 5.1.0'
 # Allows for easier meta tag setting
 gem 'metamagic'
 
+# Paginate all the things
+gem 'will_paginate'
+
 # Allows for use of Haml rather than standard erb
 gem 'haml'
 gem 'haml-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,6 +417,7 @@ GEM
       debug_inspector
       railties (>= 4.2)
     websocket (1.2.3)
+    will_paginate (3.1.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -479,6 +480,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn
   web-console
+  will_paginate
 
 BUNDLED WITH
    1.11.2

--- a/app/assets/stylesheets/components/pagination.scss
+++ b/app/assets/stylesheets/components/pagination.scss
@@ -1,0 +1,27 @@
+.news-feed--paginate {
+  text-align: center;
+}
+.news-feed--paginate a,
+.news-feed--paginate span,
+.news-feed--paginate em {
+  display: inline-block;
+  margin-right: 1px;
+  padding: .2em .5em;
+}
+
+.news-feed--paginate .disabled {
+  border: 1px solid $sub-color-3;
+  color: $sub-color-2;
+}
+
+.news-feed--paginate a {
+  border: 1px solid $sub-color;
+  color: $main-color;
+  text-decoration: none;
+}
+
+.news-feed--paginate a:hover,
+.news-feed--paginate a:focus {
+  border-color: $link-color;
+  color: $link-color;
+}

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -4,7 +4,9 @@ class ArticlesController < ApplicationController
   before_action :set_article, only: [:show, :edit, :update, :destroy]
 
   def index
-    @articles = Article.all.order('date DESC')
+    @articles = Article.all.
+      paginate(:page => params[:page], :per_page => 10).
+      order('date DESC')
   end
 
   def show

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -1,3 +1,17 @@
 # Articles Helper
 module ArticlesHelper
+  # https://github.com/mpolakis/will_paginate/blob/c388e3ac0afc114ef2aa304c00737ad911f0146b/lib/will_paginate/view_helpers.rb#L122
+  # From an unmerged part of the will_paginate gem
+  # Generates links to be put in the <head> for SEO purposes.
+  def pagination_link_tags(collection, params = {})
+    output = []
+    link = '<link rel="%s" href="%s" />'.freeze
+    output << link % ['prev'.freeze,
+      url_for(params.merge(page: collection.previous_page, only_path: false)
+      )] if collection.previous_page
+    output << link % ['next'.freeze,
+      url_for(params.merge(page: collection.next_page, only_path: false))
+      ] if collection.next_page
+    output.join('\n'.freeze).html_safe
+  end
 end

--- a/app/views/articles/_news_feed.html.haml
+++ b/app/views/articles/_news_feed.html.haml
@@ -1,7 +1,12 @@
+- content_for :head do
+  = pagination_link_tags articles
+
 %section.news-feed
-  - if articles.length > 0
+  - if !articles.empty?
     - articles.each do |article|
       = render '/articles/thumb', article: article
+    .news-feed--paginate
+      = will_paginate articles, page_links: false
   - else
     .row
       .column.small-12

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -43,11 +43,13 @@
       sizes: '32x32', type: 'image/png'
     %meta{ name: 'msapplication-TileColor', content: '#ffffff' }
     %meta{ name: 'msapplication-TileImage',
-      content: "#{image_path('favicons/mstile-144x144.png')}" }
+      content: image_path('favicons/mstile-144x144.png') }
 
     %meta{ name: 'mobile-web-app-capable', content: 'yes' }
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1.0' }
 
-  %body{ class: "#{controller.controller_name}",
-    id: "#{controller.action_name}" }
+    = yield :head
+
+  %body{ class: controller.controller_name,
+    id: controller.action_name }
     = render 'layouts/navbar'

--- a/spec/controllers/articles_controller_spec.rb
+++ b/spec/controllers/articles_controller_spec.rb
@@ -11,7 +11,7 @@ describe ArticlesController do
 
   describe 'GET index' do
     before :each do
-      @created_articles = create_list(:article, rand(5..20))
+      @created_articles = create_list(:article, rand(5..10))
     end
 
     it 'assigns @articles to all articles' do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -19,9 +19,9 @@ describe Article do
     expect(article.safe_date).to eq 'June 19, 2016'
   end
 
-  describe 'getting all current articles' do
-    it 'returns all articles marked current' do
-      created_current = create_list(:article, 14, current: true)
+  describe 'getting first page of articles' do
+    it 'returns first page of articles marked current' do
+      created_current = create_list(:article, 10, current: true)
       expect(Article.current).to match_array created_current
     end
   end


### PR DESCRIPTION
In case the number of articles get too long, the list will now
paginate for every 10 articles. In addition, to be sure CalTaiko
remains at the top of Google search results, rel next and previous
links are added to the header automatically.

closes: https://github.com/calraijintaiko/caltaiko/issues/15
